### PR TITLE
chore: rename Angular -> AngularJS

### DIFF
--- a/Criteria/JS/code_analysis/EvaluateCodeQuality_AngularJSCosmoPage_avg_high_criteria.yaml
+++ b/Criteria/JS/code_analysis/EvaluateCodeQuality_AngularJSCosmoPage_avg_high_criteria.yaml
@@ -28,5 +28,5 @@ evaluation_steps:
 metadata:
   category: EvaluateCodeQuality_AngularCosmoPage_avg_high
   experiment: code_analysis
-  repository: angular_cosmo_page
+  repository: angularjs_cosmo_page
   scenario_id: 20

--- a/Criteria/JS/code_explanation/DescribeTechnicalImplementation_AngularJSCosmoPage_avg_high_criteria.yaml
+++ b/Criteria/JS/code_explanation/DescribeTechnicalImplementation_AngularJSCosmoPage_avg_high_criteria.yaml
@@ -29,5 +29,5 @@ evaluation_steps:
 metadata:
   category: DescribeTechnicalImplementation_AngularCosmoPage_avg_high
   experiment: code_explanation
-  repository: angular_cosmo_page
+  repository: angularjs_cosmo_page
   scenario_id: 17

--- a/Criteria/JS/solution_documentation/BusinessFunctionality_AngularJSCosmoPage_avg_high_criteria.yaml
+++ b/Criteria/JS/solution_documentation/BusinessFunctionality_AngularJSCosmoPage_avg_high_criteria.yaml
@@ -42,5 +42,5 @@ evaluation_steps:
 metadata:
   category: BusinessFunctionality_AngularCosmoPage_avg_high
   experiment: solution_documentation
-  repository: angular_cosmo_page
+  repository: angularjs_cosmo_page
   scenario_id: 14

--- a/Criteria/JS/solution_migration/AngularToReact_AngularJSCosmoPage_avg_high_criteria.yaml
+++ b/Criteria/JS/solution_migration/AngularToReact_AngularJSCosmoPage_avg_high_criteria.yaml
@@ -32,7 +32,7 @@ evaluation_steps:
   - Verify that all translation functionality is preserved
   - Confirm that the application maintains the same URL structure and parameters
 metadata:
-  category: AngularToReact_AngularCosmoPage_avg_high
+  category: AngularToReact_AngularJSCosmoPage_avg_high
   experiment: solution_migration
-  repository: angular_cosmo_page
+  repository: angularjs_cosmo_page
   scenario_id: 7

--- a/Criteria/JS/test_generation/WriteTestsForLegacyCode_AngularJSCosmoPage_avg_high_criteria.yaml
+++ b/Criteria/JS/test_generation/WriteTestsForLegacyCode_AngularJSCosmoPage_avg_high_criteria.yaml
@@ -32,5 +32,5 @@ evaluation_steps:
 metadata:
   category: WriteTestsForLegacyCode_AngularCosmoPage_avg_high
   experiment: test_generation
-  repository: angular_cosmo_page
+  repository: angularjs_cosmo_page
   scenario_id: 4


### PR DESCRIPTION
- distinguish Angular (2+) and AngularJS frameworks by name